### PR TITLE
Update PluginInfo.cs

### DIFF
--- a/Model/PluginInfo.cs
+++ b/Model/PluginInfo.cs
@@ -282,7 +282,7 @@ namespace RMA.RhiExec.Model
         return 1;
 
       // See if version numbers differ
-      int comp = this.VersionNumber.CompareTo(cf);
+      int comp = this.VersionNumber.CompareTo(cf.VersionNumber);
       if (comp != 0)
         return comp;
 


### PR DESCRIPTION
Correct check in CompareTo.
See http://discourse.mcneel.com/t/rhino-installer-engine-error-when-installing-system-argumentexception/6183.
